### PR TITLE
Declare Homebridge 2.0 compatibility in engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,26 +1,26 @@
 {
-	"name": "homebridge-mobilealerts",
-	"version": "2.2.0",
-	"description": "This is a homebridge plugin for several Mobile-Alerts (Technoline) devices.",
-	"main": "index.js",
-	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
-	},
-	"keywords": [
-		"homebridge-plugin"
-	],
-	"engines": {
-		"node": ">=0.12.0",
-		"homebridge": ">=0.2.0"
-	},
-	"author": "d3h56r",
-	"license": "ISC",
-	"repository": {
-		"type": "git",
-		"url": "git://github.com/dehsgr/homebridge-mobilealerts.git"
-	},
-	"dependencies": {
-		"request": "^2.75.0",
-		"utf8": "^3.0.0"
-	}
+    "name": "homebridge-mobilealerts",
+    "version": "2.3.0",
+    "description": "This is a homebridge plugin for several Mobile-Alerts (Technoline) devices.",
+    "main": "index.js",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "keywords": [
+        "homebridge-plugin"
+    ],
+    "engines": {
+        "node": "^18 || ^20 || ^22 || >=24",
+        "homebridge": "^1.6.0 || >=2.0.0"
+    },
+    "author": "d3h56r",
+    "license": "ISC",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/dehsgr/homebridge-mobilealerts.git"
+    },
+    "dependencies": {
+        "request": "^2.75.0",
+        "utf8": "^3.0.0"
+    }
 }


### PR DESCRIPTION
This updates the `engines` field in package.json to declare compatibility 
with Homebridge 2.0.

I audited the source for the breaking changes listed on the Homebridge v2 
wiki (BatteryService removal, Characteristic.Units/Formats/Perms enums, 
getServiceByUUIDAndSubType, updateReachability, setPrimaryService(Service), 
Characteristic.getValue(), legacy camera APIs). None are present — the 
plugin only uses stable Homebridge APIs that are unchanged in v2.

Tested on Homebridge 1.x and 2.0 with Node 24 — sensors continue to report 
normally and the v2 Readiness panel shows green.

Also bumped the supported Node range to current LTS lines, since the 
existing `>=0.12.0` is from 2017 and Node 0.12 has been EOL for nearly 
a decade.

Reference: https://github.com/homebridge/homebridge/wiki/Updating-To-Homebridge-v2.0